### PR TITLE
Jb branch

### DIFF
--- a/modules/permissions-errors.sch
+++ b/modules/permissions-errors.sch
@@ -4,4 +4,9 @@
         <rule context="license">
             <assert test="normalize-space(@xlink:href)">ERROR: &lt;license&gt; must have an @xlink:href that refers to a publicly available license.</assert>
         </rule>
+		  
+		  <rule context="copyright-year">
+		  		<assert test="number() and number() &gt; 999 and number() &lt; 10000">ERROR: &lt;copyright-year&gt; must be a 4-digit year, not "<value-of select="."/>".</assert>
+		  </rule>
+		  
     </pattern>

--- a/modules/permissions-errors.sch
+++ b/modules/permissions-errors.sch
@@ -7,6 +7,11 @@
             <assert test="normalize-space(@xlink:href)">ERROR: &lt;license&gt; must have an @xlink:href that refers to a publicly available license.</assert>
         </rule>
 		  
+		  		  <!-- <copyright-statement> must be followed by a <copyright-year> -->
+		  <rule context="copyright-statement">
+		  		<assert test="following-sibling::copyright-year">ERROR: If a &lt;copyright-statement&gt; is provided,  &lt;copyright-year&gt; must also be provided for machine-readability.</assert>
+		  </rule>
+		  
 		  <!-- <copyright-year> should be a 4-digit number -->
 		  <rule context="copyright-year">
 		  		<assert test="number() and number() &gt; 999 and number() &lt; 10000">ERROR: &lt;copyright-year&gt; must be a 4-digit year, not "<value-of select="."/>".</assert>

--- a/modules/permissions-errors.sch
+++ b/modules/permissions-errors.sch
@@ -1,10 +1,13 @@
  
     <!-- tests for permissions, JATS4R GitHub issues #2, #11, #13 -->
 <pattern id="permissions-errors"  xmlns="http://purl.oclc.org/dsdl/schematron">
+
+		  <!-- <license> must have an @xlink:href to the license URI -->
         <rule context="license">
             <assert test="normalize-space(@xlink:href)">ERROR: &lt;license&gt; must have an @xlink:href that refers to a publicly available license.</assert>
         </rule>
 		  
+		  <!-- <copyright-year> should be a 4-digit number -->
 		  <rule context="copyright-year">
 		  		<assert test="number() and number() &gt; 999 and number() &lt; 10000">ERROR: &lt;copyright-year&gt; must be a 4-digit year, not "<value-of select="."/>".</assert>
 		  </rule>

--- a/modules/permissions-warnings.sch
+++ b/modules/permissions-warnings.sch
@@ -1,8 +1,8 @@
 
 <pattern id="permissions-warnings" xmlns="http://purl.oclc.org/dsdl/schematron">
 
-		  <!-- <copyright-year> should be a 4-digit number -->
+		  <!-- <copyright-statement> should be followed by a <copyright-holder> -->
 		  <rule context="copyright-statement">
-		  		<assert test="following-sibling::copyright-year and following-sibling::copyright-holder">WARNING: If a &lt;copyright-statement&gt; is provided, &lt;copyright-year&gt; and &lt;copyright-holder&gt; should also be provided for machine-readability.</assert>
+		  		<assert test="following-sibling::copyright-holder">WARNING: If a &lt;copyright-statement&gt; is provided,  &lt;copyright-holder&gt; should also be provided for machine-readability.</assert>
 		  </rule>
 	</pattern>

--- a/modules/permissions-warnings.sch
+++ b/modules/permissions-warnings.sch
@@ -1,2 +1,8 @@
 
-<pattern id="permissions-warnings"  xmlns="http://purl.oclc.org/dsdl/schematron"/>
+<pattern id="permissions-warnings" xmlns="http://purl.oclc.org/dsdl/schematron">
+
+		  <!-- <copyright-year> should be a 4-digit number -->
+		  <rule context="copyright-statement">
+		  		<assert test="following-sibling::copyright-year and following-sibling::copyright-holder">WARNING: If a &lt;copyright-statement&gt; is provided, &lt;copyright-year&gt; and &lt;copyright-holder&gt; should also be provided for machine-readability.</assert>
+		  </rule>
+	</pattern>


### PR DESCRIPTION
Updates to the license ERROR and WARNING tests based on discussions at the 2015-01-22 call. 

If <copyright-statement>:
    there MUST be a <copyright-year>;
   there SHOULD be a <copyright-statement>.

If <copyright-year>
   it MUST be a 4-digit number.