### PR TITLE
Cosmetic changes: reformating schematrons

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,77 @@ This directory contains XSL2 files that have been generated from the Schematrons
 When run against an instance, they will generate a report in Schematron Validation Report Language XML (svrl; http://www.schematron.com/validators.html)
 
 These were created for users who may have trouble applying Schematron directly in their system. They were created using iso-svrl.xsl.
+
+## Getting Saxon
+
+Download and extract the open-source Saxon Home Edition, which is written in Java, and will work on most platforms. You can download it from [here](http://sourceforge.net/projects/saxon/files/Saxon-HE/). Navigate to the latest version, and follow the instructions (which appear after the list of files). As a shortcut, you can download version 9.5 (which is known to work with these XSLTs) from the command line directly:
+
+    wget http://sourceforge.net/projects/saxon/files/Saxon-HE/9.5/SaxonHE9-5-1-5J.zip
+
+Unzip that into some subdirectory of your choosing. For example (on a unix-like operating system):
+
+    unzip -d ~/saxon9he SaxonHE9-5-1-5J.zip
+
+Set an environment variable SAXON_JAR to point to the executable Jar file. For example:
+
+    export SAXON_JAR=~/saxon9he/saxon9he.jar
+
+If your version of Saxon is in a different location, then, of course, set this environment variable appropriately.
+
+On Windows, for example, depending on the location you unzipped it to:
+
+    set SAXON_JAR=C:\bin\saxon9he\saxon9he.jar
+
+## Getting the ISO Schematron implementation
+
+You'll need to download iso-schematron-xslt2.zip from [this Schematron page](http://www.schematron.com/implementation.html), and extract it to some 
+directory of your choosing. Then, set the environment variable SVRL_XSLT to point to the iso_svrl_for_xslt2.xsl file within 
+that directory. For example:
+
+    wget http://www.schematron.com/tmp/iso-schematron-xslt2.zip
+    unzip -d ~/iso-schematron-xslt2 iso-schematron-xslt2.zip
+    export SVRL_XSLT=~/iso-schematron-xslt2/iso_svrl_for_xslt2.xsl
+
+## Preparing schematron XSLTs
+
+Now, you should be able to convert the Schematron files here into XSLTs, 
+which are used to do the actual validation.  For example, for unix-like operating
+systems:
+
+    java -jar $SAXON_JAR -o:jats4r-errlevel-0.xsl -s:jats4r-errlevel-0.sch $SVRL_XSLT
+
+Or, for Windows:
+
+    java -jar %SAXON_JAR% -o:jats4r-errlevel-0.xsl -s:jats4r-errlevel-0.sch %SVRL_XSLT%
+
+## Getting the catalog resolver
+
+Depending on whether or not your JATS files use DTDs, and how those are specified, 
+you might need to install the [Apache OASIS catalog 
+resolver](http://projects.apache.org/projects/xml_commons_resolver.html) library, which you can
+get from [their download page](http://xerces.apache.org/mirrors.cgi). At the time of this writing,
+the resolver can be downloaded from 
+[http://apache.mirrors.pair.com//xerces/xml-commons/xml-commons-resolver-1.2.zip]().
+
+Download that, extract it, and then set the RESOLVER environment variable to point to it:
+
+    wget http://apache.mirrors.pair.com//xerces/xml-commons/xml-commons-resolver-1.2.zip
+    unzip -d ~/xml-commons-resolver-1.2 xml-commons-resolver-1.2.zip
+    export RESOLVER=~/xml-commons-resolver-1.2/resolver.jar
+
+
+## Validating a JATS file
+
+For validation, we'll run Saxon, but now, since we are using external jar file libraries
+(the catalog resolver) we can't use the `-jar` shortcut. Instead, specify the location of
+Saxon as well as the library in the CLASSPATH.  On unix-like operating systems:
+
+    export CLASSPATH=$SAXON_JAR:$RESOLVER
+
+Or, on Windows:
+
+    export CLASSPATH=%SAXON_JAR%;%RESOLVER%
+
+Finally, to validate a JATS file named sample.xml, enter the following (Unix and Windows are the same):
+
+    java net.sf.saxon.Transform -catalog:../../klortho/jatspan/jatspacks/catalog.xml -s:sample.xml -xsl:jats4r-errlevel-0.xsl -o:report.xml

--- a/jats4r-errlevel-0.sch
+++ b/jats4r-errlevel-0.sch
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://purl.oclc.org/dsdl/schematron"
-    queryBinding="xslt2" defaultPhase="errors">
-    
+
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2" defaultPhase="errors">
+
     <ns prefix="mml" uri="http://www.w3.org/1998/Math/MathML"/>
     <ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
     <ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
-    
+
     <phase id="errors">
         <active pattern="permissions-errors"/>
         <active pattern="math-errors"/>
     </phase>
-    
+
     <phase id="warnings">
         <active pattern="permissions-errors"/>
         <active pattern="permissions-warnings"/>
         <active pattern="math-errors"/>
         <active pattern="math-warnings"/>
-     </phase>
-    
+    </phase>
+
     <phase id="info">
         <active pattern="permissions-errors"/>
         <active pattern="permissions-warnings"/>
@@ -26,16 +26,13 @@
         <active pattern="math-warnings"/>
         <active pattern="math-info"/>
     </phase>
-    
-     
+
     <include href="modules/permissions-errors.sch"/>
     <include href="modules/permissions-warnings.sch"/>
     <include href="modules/permissions-info.sch"/>
-    
+
     <include href="modules/math-errors.sch"/>
     <include href="modules/math-warnings.sch"/>
     <include href="modules/math-info.sch"/>
-    
-    
-      
-   </schema>
+
+</schema>

--- a/jats4r-topic-0.sch
+++ b/jats4r-topic-0.sch
@@ -1,32 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://purl.oclc.org/dsdl/schematron"
-    queryBinding="xslt2">
-    
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+
     <ns prefix="mml" uri="http://www.w3.org/1998/Math/MathML"/>
     <ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
     <ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
-    
+
     <phase id="permissions">
         <active pattern="permissions-errors"/>
         <active pattern="permissions-warnings"/>
         <active pattern="permissions-info"/>
     </phase>
-    
+
     <phase id="math">
         <active pattern="math-errors"/>
         <active pattern="math-warnings"/>
         <active pattern="math-info"/>
-     </phase>
-    
-      
+    </phase>
+
     <include href="modules/permissions-errors.sch"/>
     <include href="modules/permissions-warnings.sch"/>
     <include href="modules/permissions-info.sch"/>
-    
+
     <include href="modules/math-errors.sch"/>
     <include href="modules/math-warnings.sch"/>
     <include href="modules/math-info.sch"/>
-    
-    
-      
-   </schema>
+
+</schema>

--- a/modules/math-errors.sch
+++ b/modules/math-errors.sch
@@ -1,17 +1,26 @@
-
-<!-- tests for math formulae -->
+<!-- 
+  Tests for math formulae 
+-->
 <pattern id="math-errors" xmlns="http://purl.oclc.org/dsdl/schematron">
-  <rule context="mml:math | tex-math">
-  <!--
-     All mathematical expressions should be enclosed in an <inline-formula> element (for expressions within the flow of text) or a <disp-formula> element (for display equations).
-	  -->
-    <assert test="ancestor::disp-formula or ancestor::inline-formula">ERROR: Math expressions must be in &lt;disp-formula&gt; or &lt;inline-formula&gt; elements. They should not appear directly in &lt;<value-of select="name(parent::node())"/>&gt;.</assert>
-  </rule>
-  
-  <rule context="disp-formula | inline-formula">
-    <assert test="count(child::graphic) + count(child::tex-math) + count(child::mml:math)&lt; 2">ERROR: Formula element should contain only one expression. If these are alternate representations of the same expression, use &lt;alternatives&gt;. If they are different expressions, tag each in its own &lt;<value-of select="name()"/>&gt;.</assert>
+    <rule context="mml:math | tex-math">
+        <!--
+          All mathematical expressions should be enclosed in an <inline-formula> element (for 
+          expressions within the flow of text) or a <disp-formula> element (for display equations).
+	    -->
+        <assert test="ancestor::disp-formula or ancestor::inline-formula">
+            ERROR: Math expressions must be in &lt;disp-formula&gt; or &lt;inline-formula&gt; 
+            elements. They should not appear directly in 
+            &lt;<value-of select="name(parent::node())"/>&gt;.
+        </assert>
+    </rule>
 
-   <!-- changed to a warning <report test="(graphic or inline-graphic) and not(mml:math or tex-math)">ERROR: All mathematical expressions should be provided in markup using either &lt;mml:math&gt; or &lt;tex-math&gt;. Do not supply math simply as graphics.</report> -->   
-	</rule>
-	
+    <rule context="disp-formula | inline-formula">
+        <assert test="count(child::graphic) + count(child::tex-math) + 
+                      count(child::mml:math) &lt; 2">
+            ERROR: Formula element should contain only one expression. If these are alternate
+            representations of the same expression, use &lt;alternatives&gt;. If they are different
+            expressions, tag each in its own &lt;<value-of select="name()"/>&gt;.
+        </assert>
+    </rule>
+
 </pattern>

--- a/modules/math-info.sch
+++ b/modules/math-info.sch
@@ -1,25 +1,22 @@
+<!-- 
+  Tests for math formulae 
+-->
+<pattern id="math-info" xmlns="http://purl.oclc.org/dsdl/schematron">
 
+    <rule context="disp-formula | inline-formula">
+        <report test="alternatives">
+            INFO: &lt;alternatives> may contain any combination of
+            representations (&lt;graphic>, &lt;mml:math>, &lt;tex-math>) but where it is used, each
+            representation should be correct, complete and logically equivalent with every other
+            representation present. There is no explicit or implied preferred representation within
+            &lt;alternatives>.
+        </report>
 
-<pattern id="math-info"  xmlns="http://purl.oclc.org/dsdl/schematron">
+        <report test="tex-math">
+            INFO: The content of the &lt;tex-math> element should be math-mode
+            LaTeX, without the delimiters that are normally used to switch into / out of math mode
+            (\\[...\\], \\(...\\), $$...$$, etc.).
+        </report>
+    </rule>
 
-  <rule context="disp-formula | inline-formula">
-  <!--
-  		<alternatives> may contain any combination of representations (<graphic>, <mml:math>, <tex-math>) but where it is used, each representation should be correct, complete and logically equivalent with every other representation present. There is no explicit or implied preferred representation within <alternatives>.
-		-->
-		<report test="alternatives">INFO: &lt;alternatives> may contain any combination of representations (&lt;graphic>, &lt;mml:math>, &lt;tex-math>) but where it is used, each representation should be correct, complete and logically equivalent with every other representation present. There is no explicit or implied preferred representation within &lt;alternatives>.</report>
-		
-		<!--
-		The content of the &lt;tex-math> element should be math-mode LaTeX, without the delimiters that are normally used to switch into / out of math mode (\\[...\\], \\(...\\), $$...$$, etc.). 
-		-->
-		<report test="tex-math">INFO: The content of the &lt;tex-math> element should be math-mode LaTeX, without the delimiters that are normally used to switch into / out of math mode (\\[...\\], \\(...\\), $$...$$, etc.). </report>
-		
-		
-		</rule>
-
-
-
-
-	</pattern>
-    
-    
-
+</pattern>

--- a/modules/math-warnings.sch
+++ b/modules/math-warnings.sch
@@ -1,12 +1,22 @@
+<!-- 
+  Tests for math formulae 
+-->
 
-<pattern id="math-warnings"  xmlns="http://purl.oclc.org/dsdl/schematron">
+<pattern id="math-warnings" xmlns="http://purl.oclc.org/dsdl/schematron">
 
-  <rule context="disp-formula | inline-formula">
-  <!--
-      The use of images to represent mathematical expressions is strongly discouraged. Math should be marked up within <inline-formula> and <disp-formula> using either <tex-math> or <mml:math>.
+    <rule context="disp-formula | inline-formula">
+        <!--
+          The use of images to represent mathematical expressions is strongly discouraged. Math 
+          should be marked up within <inline-formula> and <disp-formula> using either <tex-math> 
+          or <mml:math>.
   		-->
-		<report test="(graphic or inline-graphic) and not(mml:math or tex-math)">WARNING: All mathematical expressions should be provided in markup using either &lt;mml:math&gt; or &lt;tex-math&gt;. The only instance in which the graphic representation of a mathematical expression should be used outside of &lt;alternatives> and without the equivalent markup is where that expression is so complicated that it cannot be represented in markup at all.</report>
-		</rule>
+        <report test="(graphic or inline-graphic) and not(mml:math or tex-math)">
+            WARNING: All
+            mathematical expressions should be provided in markup using either &lt;mml:math&gt; or
+            &lt;tex-math&gt;. The only instance in which the graphic representation of a
+            mathematical expression should be used outside of &lt;alternatives> and without the
+            equivalent markup is where that expression is so complicated that it cannot be
+            represented in markup at all.
+        </report>
+    </rule>
 </pattern>
-    
-

--- a/modules/permissions-errors.sch
+++ b/modules/permissions-errors.sch
@@ -1,24 +1,49 @@
-    <!-- tests for permissions, JATS4R GitHub issues #2, #11, #13 -->
-<pattern id="permissions-errors"  xmlns="http://purl.oclc.org/dsdl/schematron">
+<!-- 
+  Tests for permissions, JATS4R GitHub issues #2, #11, #13 
+-->
+<pattern id="permissions-errors" xmlns="http://purl.oclc.org/dsdl/schematron">
 
-		  <!-- <license> must have an @xlink:href to the license URI -->
-        <rule context="license">
-            <assert test="normalize-space(@xlink:href)">ERROR: &lt;license&gt; must have an @xlink:href that refers to a publicly available license.</assert>
-				<report test="@license-type">ERROR: @license-type is not machine readable and therefore should not be used. License type information should be derived instead from the URI given in the @xlink:href attribute.</report>
-        </rule>
-		  
-		  		  <!-- <copyright-statement> must be followed by a <copyright-year> -->
-		  <rule context="copyright-holder">
-		  		<assert test="preceding-sibling::copyright-year">ERROR: The &lt;copyright-year> and &lt;copyright-holder> elements are intended for machine-readability. Therefore, when there is a copyright (i.e. the article is not in the public domain) we recommend that both of these elements be used. </assert>
-		  </rule>
-		  <rule context="copyright-year">
-		  		<assert test="following-sibling::copyright-holder">ERROR: The &lt;copyright-year> and &lt;copyright-holder> elements are intended for machine-readability. Therefore, when there is a copyright (i.e. the article is not in the public domain) we recommend that both of these elements be used. </assert>
-		  </rule>
-		  
-		  <!-- <copyright-year> should be a 4-digit number -->
-		  <rule context="copyright-year">
-		  		<assert test="number() and number() &gt; 999 and number() &lt; 10000">ERROR: &lt;copyright-year&gt; must be a 4-digit year, not "<value-of select="."/>".</assert>
-				<report test="normalize-space(string(.))!=string(.)">ERROR: &lt;copyright-year&gt; should not contain whitespace.</report>
-		  </rule>
-		  
-    </pattern>
+    <!-- <license> must have an @xlink:href to the license URI -->
+    <rule context="license">
+        <assert test="normalize-space(@xlink:href)">
+            ERROR: &lt;license&gt; must have an @xlink:href
+            that refers to a publicly available license.
+        </assert>
+        <report test="@license-type">
+            ERROR: @license-type is not machine readable and therefore
+            should not be used. License type information should be derived instead from the URI
+            given in the @xlink:href attribute.
+        </report>
+    </rule>
+
+    <!-- <copyright-statement> must be followed by a <copyright-year> -->
+    <rule context="copyright-holder">
+        <assert test="preceding-sibling::copyright-year">
+            ERROR: The &lt;copyright-year> and
+            &lt;copyright-holder> elements are intended for machine-readability. Therefore, when
+            there is a copyright (i.e. the article is not in the public domain) we recommend that
+            both of these elements be used. 
+        </assert>
+    </rule>
+    
+    <rule context="copyright-year">
+        <assert test="following-sibling::copyright-holder">
+            ERROR: The &lt;copyright-year> and
+            &lt;copyright-holder> elements are intended for machine-readability. Therefore, when
+            there is a copyright (i.e. the article is not in the public domain) we recommend that
+            both of these elements be used. 
+        </assert>
+    </rule>
+
+    <!-- <copyright-year> should be a 4-digit number -->
+    <rule context="copyright-year">
+        <assert test="number() and number() &gt; 999 and number() &lt; 10000">
+            ERROR: &lt;copyright-year&gt; must be a 4-digit year, not "<value-of select="."/>".
+        </assert>
+        <report test="normalize-space(string(.))!=string(.)">
+            ERROR: &lt;copyright-year&gt; should
+            not contain whitespace.
+        </report>
+    </rule>
+
+</pattern>

--- a/modules/permissions-info.sch
+++ b/modules/permissions-info.sch
@@ -1,30 +1,48 @@
 
-<pattern id="permissions-info"  xmlns="http://purl.oclc.org/dsdl/schematron">
-	
-	<rule context="license">
-		<!--
-			The &lt;license-p> element is intended to be human-readable documentation, and any content is allowed, including, for example, &lt;ext-link> elements with URIs. Such URIs within the <license-p> element will be ignored. (It is the responsibility of the content producer to ensure that the human-readable version of the license statement matches the (machine-readable) license URI.)
-			-->
-		<report test="license-p[1]">INFO: The &lt;license-p> element is intended to be human-readable documentation, and any content is allowed, including, for example, &lt;ext-link> elements with URIs. Such URIs within the &lt;license-p> element will be ignored. (It is the responsibility of the content producer to ensure that the human-readable version of the license statement matches the (machine-readable) license URI.)</report>
-		<report test="p[1]">INFO: The &lt;p> element in &lt;license> is intended to be human-readable documentation, and any content is allowed, including, for example, &lt;ext-link> elements with URIs. Such URIs within the &lt;license-p> element will be ignored. (It is the responsibility of the content producer to ensure that the human-readable version of the license statement matches the (machine-readable) license URI.)</report>
-		</rule>
+<pattern id="permissions-info" xmlns="http://purl.oclc.org/dsdl/schematron">
 
+    <rule context="license">
+        <report test="license-p[1]">
+            INFO: The &lt;license-p> element is intended to be
+            human-readable documentation, and any content is allowed, including, for example,
+            &lt;ext-link> elements with URIs. Such URIs within the &lt;license-p> element will be
+            ignored. (It is the responsibility of the content producer to ensure that the
+            human-readable version of the license statement matches the (machine-readable) license
+            URI.)
+        </report>
+        <report test="p[1]">
+            INFO: The &lt;p> element in &lt;license> is intended to be
+            human-readable documentation, and any content is allowed, including, for example,
+            &lt;ext-link> elements with URIs. Such URIs within the &lt;license-p> element will be
+            ignored. (It is the responsibility of the content producer to ensure that the
+            human-readable version of the license statement matches the (machine-readable) license
+            URI.)
+        </report>
+    </rule>
 
-        <rule context="license/p | license/license-p">
-            <report test="ext-link">INFO: Any link in the text of a license should be to a human-readable license that does not contradict the machine-readable lincense referenced at license/@xlink:href.</report>
-        </rule>
-		  
-		  
-	<rule context="copyright-statement">
-		<report test="self::node()">INFO: The content of the &lt;copyright-statement> is intended for display; i.e. human consumption. Therefore, the contents of this element aren't addressed by these recommendations.</report>
-		</rule>	  
-		  
-		  
-	<rule context="copyright-holder">
-		<report test="self::node()">INFO: The &lt;copyright-holder> element should identify the person or institution that holds the copyright. As yet, we have no recommendations regarding the manner in which that person or institution is identified (i.e. no recommendations for using any particular authority).</report>
-		</rule>	  
-		  
-    </pattern>
-    
-    
- 
+    <rule context="license/p | license/license-p">
+        <report test="ext-link">
+            INFO: Any link in the text of a license should be to a
+            human-readable license that does not contradict the machine-readable lincense referenced
+            at license/@xlink:href.
+        </report>
+    </rule>
+
+    <rule context="copyright-statement">
+        <report test="self::node()">
+            INFO: The content of the &lt;copyright-statement> is intended
+            for display; i.e. human consumption. Therefore, the contents of this element aren't
+            addressed by these recommendations.
+        </report>
+    </rule>
+
+    <rule context="copyright-holder">
+        <report test="self::node()">
+            INFO: The &lt;copyright-holder> element should identify the
+            person or institution that holds the copyright. As yet, we have no recommendations
+            regarding the manner in which that person or institution is identified (i.e. no
+            recommendations for using any particular authority).
+        </report>
+    </rule>
+
+</pattern>

--- a/modules/permissions-warnings.sch
+++ b/modules/permissions-warnings.sch
@@ -1,8 +1,12 @@
 
 <pattern id="permissions-warnings" xmlns="http://purl.oclc.org/dsdl/schematron">
 
-		  <!-- <copyright-statement> should be followed by a <copyright-holder> -->
-		  <rule context="copyright-statement">
-		  		<assert test="following-sibling::copyright-holder">WARNING: If a &lt;copyright-statement&gt; is provided,  &lt;copyright-holder&gt; should also be provided for machine-readability.</assert>
-		  </rule>
-	</pattern>
+    <!-- <copyright-statement> should be followed by a <copyright-holder> -->
+    <rule context="copyright-statement">
+        <assert test="following-sibling::copyright-holder">
+            WARNING: If a &lt;copyright-statement&gt;
+            is provided, &lt;copyright-holder&gt; should also be provided for
+            machine-readability.
+        </assert>
+    </rule>
+</pattern>


### PR DESCRIPTION
Hey, Jeff,
I worked on this a little bit today -- I am trying to put together instructions for how somebody else might use the schematrons without any prior infrastructure setup.  I couldn't help myself, and gave all the schematrons a cosmetic once-over, here:  just formatting and indenting.
Please take a look and merge this, if you don't mind the changes.  Then, make sure you do a `git pull` in your local working repository so that you get these changes.
Thanks!